### PR TITLE
updating package.json to no longer point to non-existant commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mocha": "^3.1.2"
   },
   "dependencies": {
-    "node-mocks-http": "github:dougmoscrop/node-mocks-http#4801dc06362a36a4d9fa27939aed4e6ff3bc437a",
+    "node-mocks-http": "github:dougmoscrop/node-mocks-http",
     "on-finished": "2.3.0",
     "query-string": "4.2.3"
   }


### PR DESCRIPTION
Seems like there was a merge 3 days ago to the following repo:
https://github.com/dougmoscrop/node-mocks-http

I am not sure, but I guess the commit this package.json was pointing to got squashed?
Anyways, I assume this change is okay.