### PR TITLE
Add option to configure callbackWaitsForEmptyEventLoop, defaulting to false

### DIFF
--- a/serverless-http.js
+++ b/serverless-http.js
@@ -18,7 +18,10 @@ module.exports = function(app, opts) {
   const options = Object.assign({}, defaultOptions, opts);
 
   return (evt, ctx, callback) => {
-    ctx.callbackWaitsForEmptyEventLoop = false;
+    
+    ctx.callbackWaitsForEmptyEventLoop = (options.callbackWaitsForEmptyEventLoop != null)
+      ? options.callbackWaitsForEmptyEventLoop
+      : false;
 
     Promise.resolve()
       .then(() => {

--- a/serverless-http.js
+++ b/serverless-http.js
@@ -19,9 +19,7 @@ module.exports = function(app, opts) {
 
   return (evt, ctx, callback) => {
     
-    ctx.callbackWaitsForEmptyEventLoop = (options.callbackWaitsForEmptyEventLoop != null)
-      ? options.callbackWaitsForEmptyEventLoop
-      : false;
+    ctx.callbackWaitsForEmptyEventLoop = !!options.callbackWaitsForEmptyEventLoop;
 
     Promise.resolve()
       .then(() => {


### PR DESCRIPTION
As discussed, in some cases you want to be sure that the event loop clears before the lambda freezes (and possibly is destroyed), so make callbackWaitsForEmptyEventLoop this configurable.

Defaulting to false to avoid breaking change.