### PR TITLE
pre-normalize contentType in binary check

### DIFF
--- a/lib/is-binary.js
+++ b/lib/is-binary.js
@@ -19,9 +19,9 @@ function isBinaryContent(headers, options) {
   const contentTypes = Array.isArray(options.binary)
     ? options.binary : BINARY_CONTENT_TYPES;
 
-  return contentTypes.some(contentType =>
-    contentType === headers['content-type']
-  );
+  const contentType = (headers['content-type'] || '').split(';')[0];
+  return !!contentType &&
+    contentTypes.some(candidate => candidate === contentType);
 }
 
 module.exports = function isBinary(headers, options) {


### PR DESCRIPTION
content-type header may be something like: `application/json; charset:utf-8`, in which case the current check will fail