### PR TITLE
Return the promise to simplify testing of handler

### DIFF
--- a/serverless-http.js
+++ b/serverless-http.js
@@ -22,7 +22,7 @@ module.exports = function(app, opts) {
 
     ctx.callbackWaitsForEmptyEventLoop = !!options.callbackWaitsForEmptyEventLoop;
 
-    Promise.resolve()
+    return Promise.resolve()
       .then(() => {
         const context = ctx || {};
         const event = cleanUpEvent(evt);


### PR DESCRIPTION
When testing with AVA it's nice to have the handler return a promise since it will automatically fail the test if the promise rejects (unless you catch it yourself). And even if you don't test it that way I guess it doesn't hurt to return it.