### PR TITLE
Correct path for non-custom endpoints 

### DIFF
--- a/lib/clean-up-event.js
+++ b/lib/clean-up-event.js
@@ -4,10 +4,10 @@ module.exports = function cleanupEvent(evt) {
   const event = evt || {};
 
   event.httpMethod = event.httpMethod || 'GET';
-  event.path = event.path || '/';
   event.body = event.body || '';
   event.headers = event.headers || {};
   event.requestContext = event.requestContext || {};
+  event.requestContext.path = event.requestContext.path || '/';
   event.requestContext.identity = event.requestContext.identity || {};
 
   return event;

--- a/lib/request.js
+++ b/lib/request.js
@@ -57,7 +57,7 @@ module.exports = class ServerlessRequest extends http.IncomingMessage {
       method: event.httpMethod,
       headers: headers,
       url: url.format({
-        pathname: event.path,
+        pathname: event.requestContext.path,
         query: event.queryStringParameters
       })
     });

--- a/test/express.js
+++ b/test/express.js
@@ -21,7 +21,9 @@ describe('express', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/'
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(418);
@@ -37,7 +39,9 @@ describe('express', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/',
+      requestContext: {
+        path: '/'
+      },
       body: 'hello, world',
       headers: {
         'Content-Type': 'text/plain',
@@ -58,7 +62,9 @@ describe('express', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/',
+      requestContext: {
+        path: '/'
+      },
       body: JSON.stringify({
         hello: 'world'
       }),
@@ -79,7 +85,9 @@ describe('express', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/',
+      requestContext: {
+        path: '/'
+      },
       queryStringParameters: {
         foo: 'bar'
       }
@@ -100,7 +108,9 @@ describe('express', () => {
 
     return request(app, {
       httpMethod: 'PUT',
-      path: '/',
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(201);
@@ -113,7 +123,9 @@ describe('express', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/file.txt',
+      requestContext: {
+        path: '/file.txt',
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(200);
@@ -130,11 +142,11 @@ describe('express', () => {
 
       return request(app, {
         httpMethod: 'GET',
-        path: '/',
         headers: {
           authorization: 'Basic QWxhZGRpbjpPcGVuU2VzYW1l'
         },
         requestContext: {
+          path: '/',
           identity: {
             sourceIp: '1.3.3.7'
           }
@@ -153,11 +165,11 @@ describe('express', () => {
 
       return request(app, {
         httpMethod: 'GET',
-        path: '/',
         headers: {
           authorization: 'Basic QWxhZGRpbjpPcGVuU2VzYW1l'
         },
         requestContext: {
+          path: '/',
           identity: {
             sourceIp: '1.3.3.7'
           }

--- a/test/generic.js
+++ b/test/generic.js
@@ -17,7 +17,9 @@ describe('generic http listener', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/'
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(418);
@@ -42,7 +44,9 @@ describe('generic http listener', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/',
+      requestContext: {
+        path: '/'
+      },
       body: 'hello, world'
     })
     .then(response => {
@@ -62,7 +66,9 @@ describe('generic http listener', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/',
+      requestContext: {
+        path: '/'
+      },
       queryStringParameters: {
         foo: 'bar'
       }
@@ -84,7 +90,9 @@ describe('generic http listener', () => {
 
     return request(app, {
       httpMethod: 'PUT',
-      path: '/',
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(200);
@@ -102,7 +110,9 @@ describe('generic http listener', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/file.txt',
+      requestContext: {
+        path: '/file.txt'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(200);
@@ -124,7 +134,9 @@ describe('generic http listener', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/'
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(200);

--- a/test/koa.js
+++ b/test/koa.js
@@ -25,7 +25,9 @@ describe('koa', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/'
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(418);
@@ -41,7 +43,9 @@ describe('koa', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/',
+      requestContext: {
+        path: '/'
+      },
       queryStringParameters: {
         x: 'y'
       }
@@ -61,7 +65,9 @@ describe('koa', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/'
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(201);
@@ -78,7 +84,9 @@ describe('koa', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/'
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(200);
@@ -100,7 +108,9 @@ describe('koa', () => {
 
     return request(app, {
       httpMethod: 'GET',
-      path: '/',
+      requestContext: {
+        path: '/'
+      },
       headers: {
         'X-Request-Id': 'abc'
       }
@@ -117,7 +127,9 @@ describe('koa', () => {
     });
     return request(app, {
       httpMethod: 'GET',
-      path: '/'
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(500);
@@ -131,7 +143,9 @@ it('auth middleware should set statusCode 401', () => {
     });
     return request(app, {
       httpMethod: 'GET',
-      path: '/'
+      requestContext: {
+        path: '/'
+      }
     })
     .then(response => {
       expect(response.statusCode).to.equal(401);
@@ -157,7 +171,9 @@ it('auth middleware should set statusCode 401', () => {
     it('should get path information when it matches exactly', () => {
       return request(app, {
         httpMethod: 'GET',
-        path: '/foo'
+        requestContext: {
+          path: '/foo'
+        }
       })
       .then(response => {
         expect(response.statusCode).to.equal(200);
@@ -168,7 +184,9 @@ it('auth middleware should set statusCode 401', () => {
     it('should get path information when it matches with params', () => {
       return request(app, {
         httpMethod: 'GET',
-        path: '/foo/baz'
+        requestContext: {
+          path: '/foo/baz'
+        }
       })
       .then(response => {
         expect(response.statusCode).to.equal(200);
@@ -179,7 +197,9 @@ it('auth middleware should set statusCode 401', () => {
     it('should get method information', () => {
       return request(app, {
         httpMethod: 'POST',
-        path: '/foo'
+        requestContext: {
+          path: '/foo'
+        }
       })
       .then(response => {
         expect(response.statusCode).to.equal(201);
@@ -190,7 +210,9 @@ it('auth middleware should set statusCode 401', () => {
     it('should allow 404s', () => {
       return request(app, {
         httpMethod: 'POST',
-        path: '/missing'
+        requestContext: {
+          path: '/missing'
+        }
       })
       .then(response => {
         expect(response.statusCode).to.equal(404);
@@ -222,7 +244,9 @@ it('auth middleware should set statusCode 401', () => {
     it('should get when it matches', function() {
       return request(app, {
         httpMethod: 'GET',
-        path: '/'
+        requestContext: {
+          path: '/'
+        }
       })
       .then((response) => {
         expect(response.statusCode).to.equal(200);
@@ -233,7 +257,9 @@ it('auth middleware should set statusCode 401', () => {
     it('should 404 when route does not match', function() {
       return request(app, {
         httpMethod: 'GET',
-        path: '/missing'
+        requestContext: {
+          path: '/missing'
+        }
       })
       .then((response) => {
         expect(response.statusCode).to.equal(404);
@@ -262,7 +288,9 @@ it('auth middleware should set statusCode 401', () => {
       });
       return request(app, {
         httpMethod: 'GET',
-        path: '/',
+        requestContext: {
+          path: '/'
+        },
         headers: {
           'Content-Type': 'application/json',
           'Content-Length': body.length
@@ -292,7 +320,9 @@ it('auth middleware should set statusCode 401', () => {
       .then((zipped) => {
         return request(app, {
           httpMethod: 'GET',
-          path: '/',
+          requestContext: {
+            path: '/'
+          },
           headers: {
             'Content-Type': 'application/json',
             'Content-Encoding': 'gzip',
@@ -317,7 +347,9 @@ it('auth middleware should set statusCode 401', () => {
       });
       return request(app, {
         httpMethod: 'DELETE',
-        path: '/',
+        requestContext: {
+          path: '/'
+        },
         headers: {
           'Content-Type': 'application/json'
         }
@@ -337,7 +369,9 @@ it('auth middleware should set statusCode 401', () => {
     it('should serve a text file', () => {
       return request(app, {
         httpMethod: 'GET',
-        path: '/test/file.txt'
+        requestContext: {
+          path: '/test/file.txt'
+        }
       })
       .then((response) => {
         expect(response.body).to.equal('this is a test\n');
@@ -359,7 +393,9 @@ it('auth middleware should set statusCode 401', () => {
     it('should serve compressed text (base64 encoded)', () => {
       return request(app, {
         httpMethod: 'GET',
-        path: '/',
+        requestContext: {
+          path: '/'
+        },
         headers: {
           'accept-encoding': 'deflate'
         }


### PR DESCRIPTION
Non-custom domain endpoints (e.g. https://xyz.execute-api.region.amazonws.com/{stage}) strip off {stage} in event.path, but event.requestContext.path is correct for all cases I believe. Also should fix #35.