### PR TITLE
Adding binary content-type wildcard support

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -42,7 +42,7 @@ serverless(app, {
 
 // set the types yourself - just like BINARY_CONTENT_TYPES but using an array you pass in, rather than an environment varaible
 serverless(app, {
-  binary: ['application/json', 'image/png']
+  binary: ['application/json', 'image/*']
 });
 
 // your own custom callback
@@ -52,5 +52,3 @@ serverless(app, {
   }
 });
 ```
-
-Note that content types are compared explicitly - there's no `image/*` type wildcards.

--- a/lib/is-binary.js
+++ b/lib/is-binary.js
@@ -19,11 +19,13 @@ function isBinaryContent(headers, options) {
   const contentTypes = [].concat(options.binary
     ? options.binary
     : BINARY_CONTENT_TYPES
+  ).map(candidate =>
+    new RegExp(`^${candidate.replace(/\*/g, '.*')}$`)
   );
 
   const contentType = (headers['content-type'] || '').split(';')[0];
   return !!contentType &&
-    contentTypes.some(candidate => candidate === contentType);
+  contentTypes.some(candidate => candidate.test(contentType));
 }
 
 module.exports = function isBinary(headers, options) {

--- a/test/is-binary.js
+++ b/test/is-binary.js
@@ -14,9 +14,17 @@ describe('is-binary', function() {
     expect(result).to.be.true;
   });
 
-  it('handles wildcards', function() {
+  it('handles wildcard', function() {
     const result = isBinary({ ['content-type']: 'image/png' }, {
       binary: ['image/*']
+    });
+
+    expect(result).to.be.true;
+  });
+
+  it('handles double wildcard', function() {
+    const result = isBinary({ ['content-type']: 'application/json' }, {
+      binary: ['*/*']
     });
 
     expect(result).to.be.true;

--- a/test/is-binary.js
+++ b/test/is-binary.js
@@ -14,6 +14,22 @@ describe('is-binary', function() {
     expect(result).to.be.true;
   });
 
+  it('handles wildcards', function() {
+    const result = isBinary({ ['content-type']: 'image/png' }, {
+      binary: ['image/*']
+    });
+
+    expect(result).to.be.true;
+  });
+
+  it('does not incorrectly handle wildcards', function() {
+    const result = isBinary({ ['content-type']: 'application/json' }, {
+      binary: ['image/*']
+    });
+
+    expect(result).to.be.false;
+  });
+
   it('force to false', function() {
     const result = isBinary({}, {
       binary: false


### PR DESCRIPTION
This adds support for wildcard `content-type` to be used in the array or environment variable used to determine if a response should be binary encoded.