### PR TITLE
Adds the multiValueQueryStringParameters option as default to the request object

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -66,11 +66,11 @@ module.exports = class ServerlessRequest extends http.IncomingMessage {
       baseUrl,
       originalUrl: url.format({
         pathname: event.requestContext.path,
-        query: event.queryStringParameters
+        query: event.multiValueQueryStringParameters || event.queryStringParameters
       }),
       url: url.format({
         pathname: event.path,
-        query: event.queryStringParameters
+        query: event.multiValueQueryStringParameters || event.queryStringParameters
       }),
     });
 


### PR DESCRIPTION
AWS now offers this multiValueQueryStringParameters option if there are duplicate params.  In many sequelize-based query systems, this is necessary for advanced search.