### PR TITLE
make content-length a string instead of number

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -44,7 +44,7 @@ module.exports = class ServerlessRequest extends http.IncomingMessage {
     const body = getBody(event, headers);
 
     if (typeof headers['content-length'] === 'undefined') {
-      headers['content-length'] = Buffer.byteLength(body);
+      headers['content-length'] = String(Buffer.byteLength(body));
     }
 
     if (typeof options.requestId === 'string' && options.requestId.length > 0) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -44,7 +44,7 @@ module.exports = class ServerlessRequest extends http.IncomingMessage {
     const body = getBody(event, headers);
 
     if (typeof headers['content-length'] === 'undefined') {
-      headers['content-length'] = String(Buffer.byteLength(body));
+      headers['content-length'] = Buffer.byteLength(body);
     }
 
     if (typeof options.requestId === 'string' && options.requestId.length > 0) {

--- a/serverless-http.js
+++ b/serverless-http.js
@@ -41,6 +41,7 @@ module.exports = function (app, opts = {}) {
       .then(res => {
         const statusCode = res.statusCode;
         const headers = Response.headers(res);
+        headers['content-length'] = String(headers['content-length']);
         const isBase64Encoded = isBinary(headers, options);
         const body = getBody(res, headers, isBase64Encoded);
 


### PR DESCRIPTION
some platforms like Netlify typecheck the headers without casting - and fail when a non string header is detected. `content-length` is the only one that is a number instead of a string, and we suspect that's not to spec. so here's a tiny PR to stringify it.

related issue (internal) https://github.com/netlify/proxy/issues/212