### PR TITLE
add `br` to the list of `BINARY_ENCODINGS`

### DIFF
--- a/lib/provider/aws/is-binary.js
+++ b/lib/provider/aws/is-binary.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const BINARY_ENCODINGS = ['gzip', 'deflate'];
+const BINARY_ENCODINGS = ['gzip', 'deflate', 'br'];
 const BINARY_CONTENT_TYPES = (process.env.BINARY_CONTENT_TYPES || '').split(',');
 
 function isBinaryEncoding(headers) {


### PR DESCRIPTION
encode brotli response as base64
fixes #105 