### PR TITLE
Adding log to API Gateway request and response

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -9,3 +9,14 @@ Before using this module, you should already understand API Gateway and AWS Lamb
 Starting with v1.5.0, `serverless-http` supports API Gateway binary modes. Binary support will base64 decode the incoming request body - when API Gateway specifies that it is encoded - and will base64 encode a response body if the `Content-Type` or `Content-Encoding` matches a known binary type/encoding. This means you can gzip your JSON or return a raw image, but it requires advanced configuration within API Gateway and is generally not fun to work with (consider yourself warned!)
 
 Existing serverless-http APIs (i.e. those that return JSON as text) should not be affected. See advanced configuration documentation for details.
+
+### Logging
+
+With logging, API Gateway requests and responses can be viewed by CloudWatch, most notably by CloudWatch Logs Insights. Use carefully and preferably only in development mode because too much logs can be generated and incur additional costs.
+
+```js
+// enable logging for event, context e response to the CloudWatch
+serverless(app, {
+  verbose: true
+});
+```

--- a/lib/provider/aws/index.js
+++ b/lib/provider/aws/index.js
@@ -3,13 +3,28 @@ const cleanUpEvent = require('./clean-up-event');
 const createRequest = require('./create-request');
 const formatResponse = require('./format-response');
 
+const TRIM_LOG_BODY_LENGTH = 1024;
+
 module.exports = options => {
   return getResponse => async (event_, context = {}) => {
     const event = cleanUpEvent(event_);
 
+    if (options.verbose) {
+      console.log(JSON.stringify({ event }, null, 2));
+      console.log(JSON.stringify({ context }, null, 2));
+    }
+
     const request = createRequest(event, options);
     const response = await getResponse(request, event, context);
 
-    return formatResponse(response, options);
+    const res = formatResponse(response, options);
+
+    if (options.verbose) {
+      console.log(JSON.stringify({ response: Object.assign({}, res, {
+        body: res.body && res.body.length > TRIM_LOG_BODY_LENGTH ? res.body.substr(0, TRIM_LOG_BODY_LENGTH) + '...' : res.body,
+      }) }, null, 2));
+    }
+
+    return res;
   };
 };


### PR DESCRIPTION
Log API Gateway requests and responses for further analysis in CloudWatch Logs Insights.