### PR TITLE
feat: Add basePath option, to allow for virtual mount points

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -12,6 +12,47 @@ module.exports.handler = serverless(app, {
 });
 ```
 
+## Base Path
+
+- **basePath**: The base path/mount point for your serverless app. Useful if you want to have multiple Lambdas to represent
+diffent portions of your application.
+
+**BEFORE:**
+
+```javascript
+app.get('/new', (req, res) => {
+  return res.send('woop');
+});
+
+module.exports.handler = serverless(app);
+```
+
+```bash
+[GET] http://localhost/transactions/new -> 404 :'(
+```
+
+**AFTER:**
+
+```javascript
+app.get('/new', (req, res) => {
+  return res.send('woop');
+});
+module.exports.handler = serverless(app, {
+  basePath: '/transactions'
+});
+```
+
+```bash
+[GET] http://localhost/transactions/new -> 200 :+1:
+```
+
+**STAGE REMOVAL:**
+BasePath will also remove pesky stage information from your URL, so the above example will also work with:
+
+```bash
+[GET] http://api-gateway.amazonaws.com/dev/v1/transactions/new -> 200!
+```
+
 ## Transformations
 
 - **request**: a *transform* for the request, before it is sent to the app

--- a/lib/provider/aws/clean-up-event.js
+++ b/lib/provider/aws/clean-up-event.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function cleanupEvent(evt) {
+module.exports = function cleanupEvent(evt, options) {
   const event = evt || {};
 
   event.httpMethod = event.httpMethod || 'GET';
@@ -10,6 +10,21 @@ module.exports = function cleanupEvent(evt) {
   event.requestContext = event.requestContext || {};
   event.requestContext.path = event.requestContext.path || event.path;
   event.requestContext.identity = event.requestContext.identity || {};
+
+  if (options.basePath) {
+    const basePathIndex = event.path.indexOf(options.basePath);
+
+    if (basePathIndex === -1) {
+      return;
+    }
+
+    if (basePathIndex === 0) {
+      event.path = event.path.replace(options.basePath, '');
+    } else {
+      event.path = event.path.substr(-(basePathIndex + 1));
+    }
+
+  }
 
   return event;
 };

--- a/lib/provider/aws/index.js
+++ b/lib/provider/aws/index.js
@@ -5,7 +5,7 @@ const formatResponse = require('./format-response');
 
 module.exports = options => {
   return getResponse => async (event_, context = {}) => {
-    const event = cleanUpEvent(event_);
+    const event = cleanUpEvent(event_, options);
 
     const request = createRequest(event, options);
     const response = await getResponse(request, event, context);

--- a/package-lock.json
+++ b/package-lock.json
@@ -996,8 +996,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "optional": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "common-js-file-extensions": {
       "version": "1.0.2",

--- a/test/base-path.js
+++ b/test/base-path.js
@@ -13,8 +13,8 @@ describe('base path', () => {
     fooApp = express();
     fooApp.get('/test', (req, res) => {
       return res.send(expectedFooResponse);
-    })
-  })
+    });
+  });
 
   it('should allow for a base path to be set', () => {
     return request(fooApp, {
@@ -25,7 +25,6 @@ describe('base path', () => {
         expect(response.statusCode).to.equal(200);
         expect(response.body).to.equal(expectedFooResponse)
       });
-
   });
 
   it('should remove stage path part', () => {
@@ -37,7 +36,5 @@ describe('base path', () => {
         expect(response.statusCode).to.equal(200);
         expect(response.body).to.equal(expectedFooResponse)
       });
-
   });
-
 });

--- a/test/base-path.js
+++ b/test/base-path.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const express = require('express');
+const expect = require('chai').expect;
+const request = require('./util/request');
+
+const expectedFooResponse = 'foo!';
+
+describe('base path', () => {
+  let fooApp;
+
+  beforeEach(() => {
+    fooApp = express();
+    fooApp.get('/test', (req, res) => {
+      return res.send(expectedFooResponse);
+    })
+  })
+
+  it('should allow for a base path to be set', () => {
+    return request(fooApp, {
+      httpMethod: 'GET',
+      path: '/foo/test'
+    }, { basePath: '/foo' })
+      .then(response => {
+        expect(response.statusCode).to.equal(200);
+        expect(response.body).to.equal(expectedFooResponse)
+      });
+
+  });
+
+  it('should remove stage path part', () => {
+    return request(fooApp, {
+      httpMethod: 'GET',
+      path: '/dev/foo/test'
+    }, { basePath: '/foo' })
+      .then(response => {
+        expect(response.statusCode).to.equal(200);
+        expect(response.body).to.equal(expectedFooResponse)
+      });
+
+  });
+
+});


### PR DESCRIPTION
I'm working with an application where we want to reason about portions of the application seperately, i.e. we have a seperate lambda for users, transactions, pictures or whatever.

This PR allows you to suggest what the "mount point"/"base path" is for the serverless application, so it knows to strip this from the incoming path.

If specified, it also strips the stage information from the path, so it can work offline and in the real world!

Fixes https://github.com/dougmoscrop/serverless-http/issues/68

**BEFORE:**

serverless.yml
```yaml
  ## TRANSACTIONS ---------------------------------------------
  transactions:
    handler: handler.default
    events:
      - http: ANY /transactions
      - http: 'ANY /transactions/{proxy+}'
```

handler.js
```javascript
app.get('/new', (req, res) => {
  return res.send('woop');
});
module.exports.default = serverless(app);
```

request: 
```bash
[GET] http://localhost/transactions/new -> 404 :'(
```

**AFTER:**

app.js
```javascript
app.get('/new', (req, res) => {
  return res.send('woop');
});
module.exports.default = serverless(app, {
  basePath: '/transactions'
});
```

request
```bash
[GET] http://localhost/transactions/new -> 200 :+1:
```
```bash
[GET] http://apigateway.amazon.com/dev/transactions/new -> 200 :+1:
```