### PR TITLE
fix: Wrap serverless function result in promise in TS definitions

### DIFF
--- a/serverless-http.d.ts
+++ b/serverless-http.d.ts
@@ -21,6 +21,6 @@ declare namespace ServerlessHttp {
 declare function serverlessHttp(
     app: ServerlessHttp.HandlerCompatibleApp,
     opts?: any
-): ServerlessHttp.LambdaPartial;
+): Promise<ServerlessHttp.LambdaPartial>;
 
 export = serverlessHttp;


### PR DESCRIPTION
When i started using serverless-http a few hours ago i had some trouble geting started with testing based on the serverless() call not having the statusCode and body attributes that I was expecting based on the TS declarations.
After some debugging I found the problem to be that the result was a promise, wrapping the expected results in a callback.
I just wanted to contribute my findings so that the process will be easier the next person.