### PR TITLE
Update typescript definitions file and improve the pre-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.0",
   "description": "Use existing web application frameworks in serverless environments",
   "main": "serverless-http.js",
+  "types": "serverless-http.d.ts",
   "engines": {
     "node": ">=8.0"
   },
@@ -14,7 +15,7 @@
     "url": "https://github.com/dougmoscrop/serverless-http"
   },
   "scripts": {
-    "pretest": "tsc --noEmit test/typecheck.ts",
+    "pretest": "tsc --strict --noEmit test/typecheck.ts",
     "test": "nyc mocha",
     "posttest": "eslint lib test",
     "test:integration": "mocha test/integration/test.js",

--- a/serverless-http.d.ts
+++ b/serverless-http.d.ts
@@ -1,26 +1,34 @@
 /// <reference types="aws-lambda" />
 
 declare namespace ServerlessHttp {
-    type FrameworkApplication = {
-        callback: Function;
-        handle: Function;
-        router: {
-            route: Function;
-        }
-        _core: {
-            _dispatch: Function;
-        }
+  export interface FrameworkApplication {
+    callback: Function;
+    handle: Function;
+    router: {
+      route: Function;
     }
-    type HandlerCompatibleApp = Function | Partial<FrameworkApplication>;
-    type LambdaPartial = (
-        event: AWSLambda.APIGatewayProxyEvent,
-        context: AWSLambda.Context
-    ) => AWSLambda.APIGatewayProxyResult;
+    _core: {
+      _dispatch: Function;
+    }
+  }
+
+  /**
+   * Handler-compatible function or application.
+   */
+  export type Application = Function | Partial<FrameworkApplication>;
+
+  /**
+   * AWS Lambda APIGatewayProxyHandler-like handler.
+   */
+  export type Handler = (
+    event: AWSLambda.APIGatewayProxyEvent,
+    context: AWSLambda.Context
+  ) => Promise<AWSLambda.APIGatewayProxyResult>;
 }
 
-declare function serverlessHttp(
-    app: ServerlessHttp.HandlerCompatibleApp,
-    opts?: any
-): Promise<ServerlessHttp.LambdaPartial>;
+/**
+ * Wraps the application into a Lambda APIGatewayProxyHandler-like handler.
+ */
+declare function ServerlessHttp(application: ServerlessHttp.Application, options?: any): ServerlessHttp.Handler;
 
-export = serverlessHttp;
+export = ServerlessHttp;

--- a/test/typecheck.ts
+++ b/test/typecheck.ts
@@ -1,6 +1,6 @@
-import serverlessHttp = require('..');
-import Koa = require('koa');
+import Koa = require("koa");
+import serverlessHttp = require("..");
 
-// Simple typescript sanity check
-serverlessHttp(() => { });
-serverlessHttp(new Koa());
+// Basic definitions check.
+const handlerWithFn: serverlessHttp.Handler = serverlessHttp(() => { });
+const handlerWithApp: serverlessHttp.Handler = serverlessHttp(new Koa());


### PR DESCRIPTION
Fixes #87:
- [The function and the namespace must match](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html) to work properly.
- The namespace should export types exposed in public declarations.
- The test should reference those types for improved coverage.
- The package should provide `types` property for IDEs to properly pick up the definitions.