### PR TITLE
feat: support SCF apigateway event structure

### DIFF
--- a/lib/provider/aws/create-request.js
+++ b/lib/provider/aws/create-request.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const url = require('url');
+const lodash = require('lodash')
 
 const Request = require('../../request');
 
@@ -27,7 +28,7 @@ function requestBody(event) {
 
 module.exports = (event, options) => {
   const method = event.httpMethod;
-  const query = event.multiValueQueryStringParameters || event.queryStringParameters || event.queryString;
+  const query = event.multiValueQueryStringParameters || lodash.merge(event.queryStringParameters, event.queryString)
   const remoteAddress = event.requestContext.identity.sourceIp;
   const headers = requestHeaders(event);
   const body = requestBody(event);

--- a/lib/provider/aws/create-request.js
+++ b/lib/provider/aws/create-request.js
@@ -27,7 +27,7 @@ function requestBody(event) {
 
 module.exports = (event, options) => {
   const method = event.httpMethod;
-  const query = event.multiValueQueryStringParameters || event.queryStringParameters;
+  const query = event.multiValueQueryStringParameters || event.queryStringParameters || event.queryString;
   const remoteAddress = event.requestContext.identity.sourceIp;
   const headers = requestHeaders(event);
   const body = requestBody(event);

--- a/test/koa.js
+++ b/test/koa.js
@@ -50,7 +50,7 @@ describe('koa', () => {
   });
 
 
-  it('basic middleware should receive queryString when not passing queryStringParameters but queryString', () => {
+  it('basic middleware should receive queryString when queryStringParameters is an empty object but queryString not', () => {
     app.use(async (ctx) => {
       ctx.body = ctx.query.x;
     });
@@ -58,6 +58,7 @@ describe('koa', () => {
     return request(app, {
       httpMethod: 'GET',
       path: '/',
+      queryStringParameters: {},
       queryString: {
         x: 'y'
       }

--- a/test/koa.js
+++ b/test/koa.js
@@ -13,7 +13,7 @@ const Koa = require('koa'),
 describe('koa', () => {
   let app;
 
-  beforeEach(function() {
+  beforeEach(function () {
     app = new Koa();
   });
 
@@ -26,10 +26,10 @@ describe('koa', () => {
       httpMethod: 'GET',
       path: '/'
     })
-    .then(response => {
-      expect(response.statusCode).to.equal(418);
-      expect(response.body).to.equal('I\'m a teapot')
-    });
+      .then(response => {
+        expect(response.statusCode).to.equal(418);
+        expect(response.body).to.equal('I\'m a teapot')
+      });
   });
 
   it('basic middleware should receive queryString', () => {
@@ -44,9 +44,27 @@ describe('koa', () => {
         x: 'y'
       }
     })
-    .then(response => {
-      expect(response.body).to.equal('y');
+      .then(response => {
+        expect(response.body).to.equal('y');
+      });
+  });
+
+
+  it('basic middleware should receive queryString when not passing queryStringParameters but queryString', () => {
+    app.use(async (ctx) => {
+      ctx.body = ctx.query.x;
     });
+
+    return request(app, {
+      httpMethod: 'GET',
+      path: '/',
+      queryString: {
+        x: 'y'
+      }
+    })
+      .then(response => {
+        expect(response.body).to.equal('y');
+      });
   });
 
   it('basic middleware should receive multi-value queryString', () => {
@@ -64,9 +82,9 @@ describe('koa', () => {
         x: ['z', 'y']
       }
     })
-    .then(response => {
-      expect(response.body).to.equal('["z","y"]');
-    });
+      .then(response => {
+        expect(response.body).to.equal('["z","y"]');
+      });
   });
 
 
@@ -80,10 +98,10 @@ describe('koa', () => {
       httpMethod: 'GET',
       path: '/'
     })
-    .then(response => {
-      expect(response.statusCode).to.equal(201);
-      expect(response.body).to.equal('{"foo":"bar"}');
-    });
+      .then(response => {
+        expect(response.statusCode).to.equal(201);
+        expect(response.body).to.equal('{"foo":"bar"}');
+      });
   });
 
   it('basic middleware should set headers', () => {
@@ -96,14 +114,14 @@ describe('koa', () => {
       httpMethod: 'GET',
       path: '/'
     })
-    .then(response => {
-      expect(response.statusCode).to.equal(200);
-      expect(response.headers).to.deep.equal({
-        'content-length': '14',
-        'content-type': 'application/json; charset=utf-8',
-        'x-test-header': 'foo'
+      .then(response => {
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers).to.deep.equal({
+          'content-length': '14',
+          'content-type': 'application/json; charset=utf-8',
+          'x-test-header': 'foo'
+        });
       });
-    });
   });
 
   it('basic middleware should get headers', () => {
@@ -120,10 +138,10 @@ describe('koa', () => {
         'X-Request-Id': 'abc'
       }
     })
-    .then(response => {
-      expect(response.statusCode).to.equal(204);
-      expect(headers['x-request-id']).to.equal('abc');
-    });
+      .then(response => {
+        expect(response.statusCode).to.equal(204);
+        expect(headers['x-request-id']).to.equal('abc');
+      });
   });
 
   it('error middleware should set statusCode and default body', () => {
@@ -134,13 +152,13 @@ describe('koa', () => {
       httpMethod: 'GET',
       path: '/'
     })
-    .then(response => {
-      expect(response.statusCode).to.equal(500);
-      expect(response.body).to.equal('Internal Server Error')
-    });
+      .then(response => {
+        expect(response.statusCode).to.equal(500);
+        expect(response.body).to.equal('Internal Server Error')
+      });
   });
 
-it('auth middleware should set statusCode 401', () => {
+  it('auth middleware should set statusCode 401', () => {
     app.use(async (ctx) => {
       ctx.throw(401, `Unauthorized: ${ctx.request.method} ${ctx.request.url}`);
     });
@@ -148,9 +166,9 @@ it('auth middleware should set statusCode 401', () => {
       httpMethod: 'GET',
       path: '/'
     })
-    .then(response => {
-      expect(response.statusCode).to.equal(401);
-    });
+      .then(response => {
+        expect(response.statusCode).to.equal(401);
+      });
   });
 
 
@@ -174,10 +192,10 @@ it('auth middleware should set statusCode 401', () => {
         httpMethod: 'GET',
         path: '/foo'
       })
-      .then(response => {
-        expect(response.statusCode).to.equal(200);
-        expect(response.body).to.equal('foo')
-      });
+        .then(response => {
+          expect(response.statusCode).to.equal(200);
+          expect(response.body).to.equal('foo')
+        });
     });
 
     it('should get path information when it matches with params', () => {
@@ -185,10 +203,10 @@ it('auth middleware should set statusCode 401', () => {
         httpMethod: 'GET',
         path: '/foo/baz'
       })
-      .then(response => {
-        expect(response.statusCode).to.equal(200);
-        expect(response.body).to.equal('baz')
-      });
+        .then(response => {
+          expect(response.statusCode).to.equal(200);
+          expect(response.body).to.equal('baz')
+        });
     });
 
     it('should get method information', () => {
@@ -196,10 +214,10 @@ it('auth middleware should set statusCode 401', () => {
         httpMethod: 'POST',
         path: '/foo'
       })
-      .then(response => {
-        expect(response.statusCode).to.equal(201);
-        expect(response.body).to.equal('Thanks')
-      });
+        .then(response => {
+          expect(response.statusCode).to.equal(201);
+          expect(response.body).to.equal('Thanks')
+        });
     });
 
     it('should allow 404s', () => {
@@ -207,13 +225,13 @@ it('auth middleware should set statusCode 401', () => {
         httpMethod: 'POST',
         path: '/missing'
       })
-      .then(response => {
-        expect(response.statusCode).to.equal(404);
-      });
+        .then(response => {
+          expect(response.statusCode).to.equal(404);
+        });
     });
   });
 
-  describe('koa-router', function() {
+  describe('koa-router', function () {
 
     beforeEach(() => {
       const router = new Router();
@@ -234,29 +252,29 @@ it('auth middleware should set statusCode 401', () => {
       app.use(router.allowedMethods());
     });
 
-    it('should get when it matches', function() {
+    it('should get when it matches', function () {
       return request(app, {
         httpMethod: 'GET',
         path: '/'
       })
-      .then((response) => {
-        expect(response.statusCode).to.equal(200);
-        expect(response.body).to.equal('hello');
-      });
+        .then((response) => {
+          expect(response.statusCode).to.equal(200);
+          expect(response.body).to.equal('hello');
+        });
     });
 
-    it('should 404 when route does not match', function() {
+    it('should 404 when route does not match', function () {
       return request(app, {
         httpMethod: 'GET',
         path: '/missing'
       })
-      .then((response) => {
-        expect(response.statusCode).to.equal(404);
-        expect(response.headers).to.deep.equal({
-          'content-length': '9',
-          'content-type': 'text/plain; charset=utf-8'
+        .then((response) => {
+          expect(response.statusCode).to.equal(404);
+          expect(response.headers).to.deep.equal({
+            'content-length': '9',
+            'content-type': 'text/plain; charset=utf-8'
+          });
         });
-      });
     });
   });
 
@@ -270,7 +288,7 @@ it('auth middleware should set statusCode 401', () => {
       const body = `{"foo":"bar"}`;
 
       let actual;
-      app.use(async(ctx) => {
+      app.use(async (ctx) => {
         ctx.status = 204;
         ctx.body = {};
         actual = ctx.request.body;
@@ -284,11 +302,11 @@ it('auth middleware should set statusCode 401', () => {
         },
         body
       })
-      .then(() => {
-        expect(actual).to.deep.equal({
-          "foo": "bar"
+        .then(() => {
+          expect(actual).to.deep.equal({
+            "foo": "bar"
+          });
         });
-      });
     });
 
     it('works with gzip (base64 encoded string)', () => {
@@ -304,24 +322,24 @@ it('auth middleware should set statusCode 401', () => {
           resolve(result);
         });
       })
-      .then((zipped) => {
-        return request(app, {
-          httpMethod: 'GET',
-          path: '/',
-          headers: {
-            'Content-Type': 'application/json',
-            'Content-Encoding': 'gzip',
-            'Content-Length': zipped.length,
-          },
-          body: zipped.toString('base64'),
-          isBase64Encoded: true
-        })
-        .then(() => {
-          expect(actual).to.deep.equal({
-            foo: "bar"
-          });
+        .then((zipped) => {
+          return request(app, {
+            httpMethod: 'GET',
+            path: '/',
+            headers: {
+              'Content-Type': 'application/json',
+              'Content-Encoding': 'gzip',
+              'Content-Length': zipped.length,
+            },
+            body: zipped.toString('base64'),
+            isBase64Encoded: true
+          })
+            .then(() => {
+              expect(actual).to.deep.equal({
+                foo: "bar"
+              });
+            });
         });
-      });
     });
 
     it('can handle DELETE with no body', () => {
@@ -337,9 +355,9 @@ it('auth middleware should set statusCode 401', () => {
           'Content-Type': 'application/json'
         }
       })
-      .then(() => {
-        expect(called).to.equal(true);
-      });
+        .then(() => {
+          expect(called).to.equal(true);
+        });
     });
   });
 
@@ -354,9 +372,9 @@ it('auth middleware should set statusCode 401', () => {
         httpMethod: 'GET',
         path: 'file.txt'
       })
-      .then((response) => {
-        expect(response.body).to.equal('this is a test\n');
-      });
+        .then((response) => {
+          expect(response.body).to.equal('this is a test\n');
+        });
     });
   });
 
@@ -379,12 +397,12 @@ it('auth middleware should set statusCode 401', () => {
           'accept-encoding': 'deflate'
         }
       })
-      .then((response) => {
-        const decoded = Buffer.from(response.body, 'base64');
-        const inflated = zlib.inflateSync(decoded);
+        .then((response) => {
+          const decoded = Buffer.from(response.body, 'base64');
+          const inflated = zlib.inflateSync(decoded);
 
-        expect(inflated.toString()).to.equal('this is a test');
-      });
+          expect(inflated.toString()).to.equal('this is a test');
+        });
     });
   });
 });


### PR DESCRIPTION
Hello, here is why i make this pr.

I try to use koa in TencentCloud Serverless Cloud Functions with serverless-http.
Everything seems ok.
But i found a case that if i create a apigateway trigger in their console, they will not configure query params in the TencentCloud Apigateway.
So when i create a function which returns ctx.query, and request the apigateway path like
```curl https://service-818xjkw2-1252618971.gz.apigw.tencentcs.com/release/blog_visit?a=1&b=2```

i can not get the query params in queryStringParameters, but in queryString and the docs of them also says this case. 
[Link](https://intl.cloud.tencent.com/document/product/583/12513)
![image](https://user-images.githubusercontent.com/23744602/70534696-847c3b80-1b96-11ea-901c-a0c9d110d714.png)


So I make a little change to adapt to this case and add a test:

![image](https://user-images.githubusercontent.com/23744602/70593788-48d68580-1c19-11ea-9786-d5968143d146.png)


Please take some time to review and merge it🌹！





