### PR TITLE
fix: [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -36,7 +36,11 @@ module.exports = class ServerlessResponse extends http.ServerResponse {
   }
 
   static headers(res) {
-    return Object.assign(res._headers, res[HEADERS]);
+    const headers = typeof res.getHeaders === 'function'
+      ? res.getHeaders()
+      : res._headers;
+
+    return Object.assign(headers, res[HEADERS]);
   }
 
   get headers() {
@@ -56,8 +60,6 @@ module.exports = class ServerlessResponse extends http.ServerResponse {
 
     this[BODY] = [];
     this[HEADERS] = {};
-
-    this._headers = {};
 
     this.useChunkedEncodingByDefault = false;
     this.chunkedEncoding = false;

--- a/test/format-response.js
+++ b/test/format-response.js
@@ -8,7 +8,7 @@ describe('format-response', function() {
 
   it('throws on chunked transfer-encoding', () => {
     const response = new Response({});
-    response._headers = { 'transfer-encoding': 'chunked' };
+    response.setHeader('transfer-encoding', 'chunked');
     expect(() => formatResponse(response, {})).to.throw(Error, 'chunked encoding not supported');
   });
 


### PR DESCRIPTION
Fixes: #130 

tested node.js version: 8.17.0, 9.11.2, 10.18.0, 11.15.0, 12.13.0, 13.5.0

All files in test folder has been successfully passed except sails.js when node.js version >= 12.13.0

I found out that there are some places using res._headers in the file which path is node_modules/sails/lib/router/res.js.

I'm going to add this issue in sails framework.