### PR TITLE
fix: intercept fastpath'ed headers through writeHead

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -55,6 +55,24 @@ module.exports = class ServerlessResponse extends http.ServerResponse {
     }
   }
 
+  writeHead(statusCode, reason, obj) {
+    const headers = typeof reason === 'string'
+      ? obj
+      : reason
+
+    for (const name in headers) {
+      this.setHeader(name, headers[name])
+
+      if(!this._wroteHeader) {
+        // we only need to initiate super.headers once
+        // writeHead will add the other headers itself
+        break
+      }
+    }
+
+    super.writeHead(statusCode, reason, obj)
+  }
+
   constructor(req) {
     super(req);
 

--- a/test/generic.js
+++ b/test/generic.js
@@ -158,4 +158,26 @@ describe('generic http listener', () => {
       });
     });
   });
+
+  it('should intercept writeHead', () => {
+    app = function(req, res) {
+      res.writeHead(302, {
+        Location: '/redirect',
+        Accept: '*/*'
+      });
+      res.end();
+    };
+
+    return request(app, {
+      httpMethod: 'GET',
+      path: '/'
+    })
+    .then(response => {
+      expect(response.statusCode).to.equal(302);
+      expect(response.headers).to.deep.equal({
+        location: '/redirect',
+        accept: '*/*'
+      });
+    });
+  });
 });


### PR DESCRIPTION
When an app uses `res.writeHead` then using `getHeaders` is unreliable as writeHead fast paths headers to the network and doesnt fill the local headers store unless setHeader has been called at least once.

This pr fixes that behaviour by intercepting writeHead because we always need the headers in the local store so we can retrieve them with getHeaders. 

For more details, see here: https://nodejs.org/api/http.html#http_response_writehead_statuscode_statusmessage_headers