### PR TITLE
aws: handling if used via new API Gateway v2 (i.e. HTTP-API) with in combination with a stage

### DIFF
--- a/lib/provider/aws/create-request.js
+++ b/lib/provider/aws/create-request.js
@@ -37,13 +37,21 @@ module.exports = (event, options) => {
     headers[header] = headers[header] || event.requestContext.requestId;
   }
 
+  let pathname = event.path
+  // NOTE: if used directly via new API Gateway v2 (i.e. HTTP-API)
+  if (event.requestContext && event.requestContext.stage && event.requestContext.resourcePath &&
+      event.path.indexOf(`/${event.requestContext.stage}/`) === 0 &&
+      event.requestContext.resourcePath.indexOf(`/${event.requestContext.stage}/`) !== 0) {
+        pathname = event.path.substring(event.requestContext.stage.length + 1)
+  }
+
   const req = new Request({
     method,
     headers,
     body,
     remoteAddress,
     url: url.format({
-      pathname: event.path,
+      pathname,
       query,
     }),
   });


### PR DESCRIPTION
Seems like the new API Gateway v2 (i.e. when using HTTP-API) does send a different event payload when used with a dedicated api stage.

The "old" API Gateway sends it like this:
```javascript
{
  httpMethod: 'GET',
  path: '/test',
  headers: {
    'X-My-Header': 'wuuusaaa'
  },
  requestContext: {
  }
}
```
The "new" API Gateway sends it like this:
```javascript
{
  httpMethod: 'GET',
  path: '/dev/test',
  headers: {
    'X-My-Header': 'wuuusaaa'
  },
  requestContext: {
    resourcePath: '/test',
    stage: 'dev'
  }
}
```

_compare the path value_