### PR TITLE
Add support for payload format version 2.0

### DIFF
--- a/lib/provider/aws/clean-up-event.js
+++ b/lib/provider/aws/clean-up-event.js
@@ -1,8 +1,13 @@
 'use strict';
 
-function getPath({ requestPath, path }) {
+function getPath({ requestPath, path, rawPath }) {
   if (requestPath) {
     return requestPath;
+  }
+
+  // Payload 2.0
+  if (rawPath) {
+    return typeof rawPath === 'string' ? rawPath : '/';
   }
 
   return typeof path === 'string' ? path : '/';
@@ -11,18 +16,36 @@ function getPath({ requestPath, path }) {
 module.exports = function cleanupEvent(evt, options) {
   const event = evt || {};
 
-  event.requestContext = event.requestContext || {};
-  event.requestContext.identity = event.requestContext.identity || {};
-  event.httpMethod = event.httpMethod || 'GET';
-  event.path = getPath(event);
-  event.body = event.body || '';
-  event.headers = event.headers || {};
+  if (!evt || !evt.version || evt.version === '1.0') {
+    event.requestContext = event.requestContext || {};
+    event.requestContext.identity = event.requestContext.identity || {};
+    event.httpMethod = event.httpMethod || 'GET';
+    event.path = getPath(event);
+    event.body = event.body || '';
+    event.headers = event.headers || {};
 
-  if (options.basePath) {
-    const basePathIndex = event.path.indexOf(options.basePath);
+    if (options.basePath) {
+      const basePathIndex = event.path.indexOf(options.basePath);
 
-    if (basePathIndex > -1) {
-      event.path = event.path.substr(basePathIndex + options.basePath.length);
+      if (basePathIndex > -1) {
+        event.path = event.path.substr(basePathIndex + options.basePath.length);
+      }
+    }
+
+  } else if (evt.version === '2.0') {
+    event.requestContext = event.requestContext || {};
+    event.requestContext.authorizer = event.requestContext.authorizer || {};
+    event.requestContext.http.method = event.requestContext.http.method || 'GET';
+    event.rawPath = getPath(event);
+    event.body = event.body || '';
+    event.headers = event.headers || {};
+
+    if (options.basePath) {
+      const basePathIndex = event.rawPath.indexOf(options.basePath);
+
+      if (basePathIndex > -1) {
+        event.rawPath = event.rawPath.substr(basePathIndex + options.basePath.length);
+      }
     }
   }
 

--- a/lib/provider/aws/create-request.js
+++ b/lib/provider/aws/create-request.js
@@ -4,6 +4,23 @@ const url = require('url');
 
 const Request = require('../../request');
 
+function requestMethod(event) {
+  if(!event || !event.version || event.version === '1.0') return event.httpMethod;
+  if (event.version === '2.0') return event.requestContext.http.method;
+}
+
+function requestQuery(event) {
+  if(!event || !event.version || event.version === '1.0')
+    return event.multiValueQueryStringParameters || event.queryStringParameters;
+
+  if (event.version === '2.0') return event.queryStringParameters;
+}
+
+function requestRemoteAddress(event) {
+  if(!event || !event.version || event.version === '1.0') return event.requestContext.identity.sourceIp;
+  if (event.version === '2.0') return event.requestContext.http.sourceIp;
+}
+
 function requestHeaders(event) {
   return Object.keys(event.headers).reduce((headers, key) => {
     headers[key.toLowerCase()] = event.headers[key];
@@ -25,12 +42,25 @@ function requestBody(event) {
   throw new Error(`Unexpected event.body type: ${typeof event.body}`);
 }
 
+function requestUrl(event, query) {
+  if(!event || !event.version || event.version === '1.0') {
+    return url.format({
+      pathname: event.path,
+      query,
+    })
+
+  } else if (event.version === '2.0') {
+    return `${event.rawPath}${event.rawQueryString ? '?'+event.rawQueryString : ''}`;
+  }
+}
+
 module.exports = (event, options) => {
-  const method = event.httpMethod;
-  const query = event.multiValueQueryStringParameters || event.queryStringParameters;
-  const remoteAddress = event.requestContext.identity.sourceIp;
+  const method = requestMethod(event);
+  const query = requestQuery(event);
+  const remoteAddress = requestRemoteAddress(event);
   const headers = requestHeaders(event);
   const body = requestBody(event);
+  const url = requestUrl(event, query);
 
   if (typeof options.requestId === 'string' && options.requestId.length > 0) {
     const header = options.requestId.toLowerCase();
@@ -42,11 +72,9 @@ module.exports = (event, options) => {
     headers,
     body,
     remoteAddress,
-    url: url.format({
-      pathname: event.path,
-      query,
-    }),
+    url,
   });
+
   req.requestContext = event.requestContext;
   return req;
 };

--- a/test/clean-up-event.js
+++ b/test/clean-up-event.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const cleanUpEvent = require('../lib/provider/aws/clean-up-event.js');
+const expect = require('chai').expect;
+
+describe('clean up event', () => {
+  it('should clean up api gateway payload format version 1.0 correctly', () => {
+    // Construct dummy v1 event
+    const v1Event = {
+      version: '1.0',
+      resource: '/my/path',
+      path: '/my/path',
+      httpMethod: 'GET',
+      headers: {
+        'Header1': 'value1',
+        'Header2': 'value2'
+      },
+      queryStringParameters: { parameter1: 'value1', parameter2: 'value' },
+      multiValueQueryStringParameters: { parameter1: ['value1', 'value2'], paramter2: ['value'] },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'id',
+        authorizer: { claims: null, scopes: null },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        extendedRequestId: 'request-id',
+        httpMethod: 'GET',
+        path: '/my/path',
+        protocol: 'HTTP/1.1',
+        requestId: 'id=',
+        requestTime: '04/Mar/2020:19:15:17 +0000',
+        requestTimeEpoch: 1583349317135,
+        resourceId: null,
+        resourcePath: '/my/path',
+        stage: '$default'
+      },
+      pathParameters: null,
+      stageVariables: null,
+      body: 'Hello from Lambda!',
+      isBase64Encoded: true
+    };
+
+    // Clean the event
+    cleanUpEvent(v1Event, { basePath: '/my' });
+
+    expect(v1Event).to.eql({
+      version: '1.0',
+      resource: '/my/path',
+      path: '/path',
+      httpMethod: 'GET',
+      headers: { Header1: 'value1', Header2: 'value2' },
+      queryStringParameters: { parameter1: 'value1', parameter2: 'value' },
+      multiValueQueryStringParameters: { parameter1: ['value1', 'value2'], paramter2: ['value'] },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'id',
+        authorizer: { claims: null, scopes: null },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        extendedRequestId: 'request-id',
+        httpMethod: 'GET',
+        path: '/my/path',
+        protocol: 'HTTP/1.1',
+        requestId: 'id=',
+        requestTime: '04/Mar/2020:19:15:17 +0000',
+        requestTimeEpoch: 1583349317135,
+        resourceId: null,
+        resourcePath: '/my/path',
+        stage: '$default',
+        identity: {}
+      },
+      pathParameters: null,
+      stageVariables: null,
+      body: 'Hello from Lambda!',
+      isBase64Encoded: true
+    });
+  });
+
+  it('should clean up api gateway payload format version 2.0 correctly', () => {
+    // Construct dummy v2 event
+    const v2Event = {
+      version: '2.0',
+      routeKey: '$default',
+      rawPath: '/my/path',
+      rawQueryString: 'parameter1=value1&parameter1=value2&parameter2=value',
+      cookies: ['cookie1', 'cookie2'],
+      headers: {
+        'Header1': 'value1',
+        'Header2': 'value2'
+      },
+      queryStringParameters: { parameter1: 'value1,value2', parameter2: 'value' },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'api-id',
+        authorizer: {
+          jwt: {
+            claims: { 'claim1': 'value1', 'claim2': 'value2' },
+            scopes: ['scope1', 'scope2']
+          }
+        },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        http: {
+          method: 'POST',
+          path: '/my/path',
+          protocol: 'HTTP/1.1',
+          sourceIp: 'IP',
+          userAgent: 'agent'
+        },
+        requestId: 'id',
+        routeKey: '$default',
+        stage: '$default',
+        time: '12/Mar/2020:19:03:58 +0000',
+        timeEpoch: 1583348638390
+      },
+      body: 'Hello from Lambda',
+      pathParameters: { 'parameter1': 'value1' },
+      isBase64Encoded: false,
+      stageVariables: { 'stageVariable1': 'value1', 'stageVariable2': 'value2' }
+    };
+
+    // Clean the event
+    cleanUpEvent(v2Event, { basePath: '/my' });
+
+    expect(v2Event).to.eql({
+      version: '2.0',
+      routeKey: '$default',
+      rawPath: '/path',
+      rawQueryString: 'parameter1=value1&parameter1=value2&parameter2=value',
+      cookies: ['cookie1', 'cookie2'],
+      headers: { Header1: 'value1', Header2: 'value2' },
+      queryStringParameters: { parameter1: 'value1,value2', parameter2: 'value' },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'api-id',
+        authorizer: {
+          jwt: {
+            claims: { 'claim1': 'value1', 'claim2': 'value2' },
+            scopes: ['scope1', 'scope2']
+          }
+        },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        http: {
+          method: 'POST',
+          path: '/my/path',
+          protocol: 'HTTP/1.1',
+          sourceIp: 'IP',
+          userAgent: 'agent'
+        },
+        requestId: 'id',
+        routeKey: '$default',
+        stage: '$default',
+        time: '12/Mar/2020:19:03:58 +0000',
+        timeEpoch: 1583348638390
+      },
+      body: 'Hello from Lambda',
+      pathParameters: { parameter1: 'value1' },
+      isBase64Encoded: false,
+      stageVariables: { stageVariable1: 'value1', stageVariable2: 'value2' }
+    });
+
+  });
+});


### PR DESCRIPTION
This addresses Issue #146 and adds support for the 2.0 API Gateway payload version, https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html This is the default for the new HTTP APIs.

I also added tests that pass in version 1 and version 2 of the payload and the assert they both have the same structure as returned by `create-request.js`