### PR TITLE
fix(types): add type support for event payload v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,9 +1349,9 @@
       }
     },
     "@types/aws-lambda": {
-      "version": "8.10.19",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.19.tgz",
-      "integrity": "sha512-dEhQow/1awGGIf/unEpb97vsTtnQ3qRPAhSmZZcXKzs4nOVbIuWo5LCCzOYdSIkGkkoFXVvc8pBaSVKRYIFUBA==",
+      "version": "8.10.56",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.56.tgz",
+      "integrity": "sha512-jaxu5br/KYxhNBNmr2GoVhIUady2zNsvSRCa4kCHW+GcM4ladPhfEyeJkkNMGo/IlVAfpcPYTsSzhYWZoSgZXA==",
       "optional": true
     },
     "@types/body-parser": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "homepage": "https://github.com/dougmoscrop/serverless-http",
   "license": "MIT",
   "optionalDependencies": {
-    "@types/aws-lambda": "^8.10.19"
+    "@types/aws-lambda": "^8.10.56"
   },
   "devDependencies": {
     "@loopback/rest": "^1.25.1",

--- a/serverless-http.d.ts
+++ b/serverless-http.d.ts
@@ -21,9 +21,9 @@ declare namespace ServerlessHttp {
    * AWS Lambda APIGatewayProxyHandler-like handler.
    */
   export type Handler = (
-    event: AWSLambda.APIGatewayProxyEvent,
+    event: AWSLambda.APIGatewayProxyEvent | AWSLambda.APIGatewayProxyEventV2,
     context: AWSLambda.Context
-  ) => Promise<AWSLambda.APIGatewayProxyResult>;
+  ) => Promise<AWSLambda.APIGatewayProxyResult | AWSLambda.APIGatewayProxyStructuredResultV2>;
 }
 
 /**


### PR DESCRIPTION
This library has been updated to support API Gateway Proxy Event Payload v2 as seen [here](https://github.com/dougmoscrop/serverless-http/blob/master/lib/provider/aws/create-request.js#L8). But, its type definitions were still outdated. This PR fixes that.