### PR TITLE
Don't set requestId header to undefined when the header is not present

### DIFF
--- a/lib/provider/aws/create-request.js
+++ b/lib/provider/aws/create-request.js
@@ -65,7 +65,10 @@ module.exports = (event, options) => {
 
   if (typeof options.requestId === 'string' && options.requestId.length > 0) {
     const header = options.requestId.toLowerCase();
-    headers[header] = headers[header] || event.requestContext.requestId;
+    const requestId = headers[header] || event.requestContext.requestId;
+    if (requestId) {
+      headers[header] = requestId;
+    }
   }
 
   const req = new Request({


### PR DESCRIPTION
Updates the code so we don't set the `requestId` header (`x-request-id`) to `undefined` when the header is not present.

This seems cleaner and fixes a bug that can occur in other code that might assume each set header will have a defined value. The `koa2-winston` package for example assumes all headers have a defined value and [crashes](https://github.com/yidinghan/koa2-winston/issues/17) when that is not the case.

Usually this is not a problem because API Gateway provides the `x-request-id` header. It is a problem however when running locally or when invoking a lambda directly with a hand crafted http event that don't have that header.
