### PR TITLE
Update type definitions to show handler now accepts APIGatewayProxyEventV2 objects

### DIFF
--- a/serverless-http.d.ts
+++ b/serverless-http.d.ts
@@ -21,7 +21,7 @@ declare namespace ServerlessHttp {
    * AWS Lambda APIGatewayProxyHandler-like handler.
    */
   export type Handler = (
-    event: AWSLambda.APIGatewayProxyEvent,
+    event: AWSLambda.APIGatewayProxyEvent | AWSLambda.APIGatewayProxyEventV2,
     context: AWSLambda.Context
   ) => Promise<AWSLambda.APIGatewayProxyResult>;
 }


### PR DESCRIPTION
Updates the TypeScript type definition file to show that the handler now accepts [`APIGatewayProxyEventV2`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/27cb7a9e89ff0bd88114d10ecc50dccd7f8ae13b/types/aws-lambda/trigger/api-gateway-proxy.d.ts#L100) objects. This was enabled in https://github.com/dougmoscrop/serverless-http/pull/150 by @TehNrd 


