### PR TITLE
Normalization of Query Params Between AWS Elastic Load Balancer and API Gateway

### DIFF
--- a/lib/provider/aws/clean-up-event.js
+++ b/lib/provider/aws/clean-up-event.js
@@ -36,11 +36,8 @@ function recursiveURLDecode(value) {
 
     return decodedObject;
   }
-  
-  return value;
 
   return value;
-
 }
 
 module.exports = function cleanupEvent(evt, options) {

--- a/lib/provider/aws/clean-up-event.js
+++ b/lib/provider/aws/clean-up-event.js
@@ -12,12 +12,53 @@ function removeBasePath(path = '/', basePath) {
   return path;
 }
 
+function recursiveURLDecode(value) {
+
+  if (typeof value === 'string' || value instanceof String) {
+    return decodeURIComponent(value);
+  } else if (Array.isArray(value)) {
+
+    const decodedArray = [];
+
+    for (let index of value) {
+      decodedArray[index] = recursiveURLDecode(value[index]);
+    }
+
+    return decodedArray;
+
+  } else if (value instanceof Object) {
+
+    const decodedObject = {};
+
+    for (let key of Object.keys(value)) {
+      decodedObject[decodeURIComponent(key)] = recursiveURLDecode(value[key]);
+    }
+
+    return decodedObject;
+  }
+
+}
+
 module.exports = function cleanupEvent(evt, options) {
   const event = evt || {};
 
   event.requestContext = event.requestContext || {};
   event.body = event.body || '';
   event.headers = event.headers || {};
+
+  // Events coming from AWS Elastic Load Balancers do not automatically urldecode query parameters (unlike API Gateway). So we need to check for that and automatically decode them
+  // to normalize the request between the two.
+  if ('elb' in event.requestContext) {
+
+    if (event.multiValueQueryStringParameters) {
+      event.multiValueQueryStringParameters = recursiveURLDecode(event.multiValueQueryStringParameters);
+    }
+
+    if (event.queryStringParameters) {
+      event.queryStringParameters = recursiveURLDecode(event.queryStringParameters);
+    }
+
+  }
 
   if (event.version === '2.0') {
     event.requestContext.authorizer = event.requestContext.authorizer || {};

--- a/lib/provider/aws/clean-up-event.js
+++ b/lib/provider/aws/clean-up-event.js
@@ -37,6 +37,8 @@ function recursiveURLDecode(value) {
     return decodedObject;
   }
 
+  return value;
+
 }
 
 module.exports = function cleanupEvent(evt, options) {

--- a/lib/provider/aws/clean-up-event.js
+++ b/lib/provider/aws/clean-up-event.js
@@ -21,7 +21,7 @@ function recursiveURLDecode(value) {
     const decodedArray = [];
 
     for (let index of value) {
-      decodedArray[index] = recursiveURLDecode(value[index]);
+      decodedArray.push(recursiveURLDecode(value[index]));
     }
 
     return decodedArray;

--- a/test/clean-up-event.js
+++ b/test/clean-up-event.js
@@ -161,4 +161,182 @@ describe('clean up event', () => {
     });
 
   });
+
+  it('should properly urldecode ELB payload query params', () => {
+    // Construct dummy v2 event
+    const v2Event = {
+      version: '2.0',
+      routeKey: '$default',
+      rawPath: '/my/path',
+      rawQueryString: 'parameter%231=value%231&parameter%231=value%232&parameter2=value',
+      cookies: ['cookie1', 'cookie2'],
+      headers: {
+        'Header1': 'value1',
+        'Header2': 'value2'
+      },
+      queryStringParameters: { 'parameter%231': 'value%231,value%232', 'parameter2': 'value' },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'api-id',
+        authorizer: {
+          jwt: {
+            claims: { 'claim1': 'value1', 'claim2': 'value2' },
+            scopes: ['scope1', 'scope2']
+          }
+        },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        http: {
+          method: 'POST',
+          path: '/my/path',
+          protocol: 'HTTP/1.1',
+          sourceIp: 'IP',
+          userAgent: 'agent'
+        },
+        requestId: 'id',
+        routeKey: '$default',
+        stage: '$default',
+        time: '12/Mar/2020:19:03:58 +0000',
+        timeEpoch: 1583348638390,
+        elb: {
+          targetGroupArn: "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+        }
+      },
+      body: 'Hello from Lambda',
+      pathParameters: { 'parameter1': 'value1' },
+      isBase64Encoded: false,
+      stageVariables: { 'stageVariable1': 'value1', 'stageVariable2': 'value2' }
+    };
+
+    // Clean the event
+    cleanUpEvent(v2Event, { basePath: '/my' });
+
+    expect(v2Event).to.eql({
+      version: '2.0',
+      routeKey: '$default',
+      rawPath: '/path',
+      rawQueryString: 'parameter%231=value%231&parameter%231=value%232&parameter2=value',
+      cookies: ['cookie1', 'cookie2'],
+      headers: { Header1: 'value1', Header2: 'value2' },
+      queryStringParameters: { 'parameter#1': 'value#1,value#2', parameter2: 'value' },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'api-id',
+        authorizer: {
+          jwt: {
+            claims: { 'claim1': 'value1', 'claim2': 'value2' },
+            scopes: ['scope1', 'scope2']
+          }
+        },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        http: {
+          method: 'POST',
+          path: '/my/path',
+          protocol: 'HTTP/1.1',
+          sourceIp: 'IP',
+          userAgent: 'agent'
+        },
+        requestId: 'id',
+        routeKey: '$default',
+        stage: '$default',
+        time: '12/Mar/2020:19:03:58 +0000',
+        timeEpoch: 1583348638390,
+        elb: {
+          targetGroupArn: "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+        }
+      },
+      body: 'Hello from Lambda',
+      pathParameters: { parameter1: 'value1' },
+      isBase64Encoded: false,
+      stageVariables: { stageVariable1: 'value1', stageVariable2: 'value2' }
+    });
+
+  });
+
+  it('should not urldecode query params for non ELB payloads', () => {
+    // Construct dummy v2 event
+    const v2Event = {
+      version: '2.0',
+      routeKey: '$default',
+      rawPath: '/my/path',
+      rawQueryString: 'parameter%231=value%231&parameter%231=value%232&parameter2=value',
+      cookies: ['cookie1', 'cookie2'],
+      headers: {
+        'Header1': 'value1',
+        'Header2': 'value2'
+      },
+      queryStringParameters: { 'parameter%231': 'value%231,value%232', 'parameter2': 'value' },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'api-id',
+        authorizer: {
+          jwt: {
+            claims: { 'claim1': 'value1', 'claim2': 'value2' },
+            scopes: ['scope1', 'scope2']
+          }
+        },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        http: {
+          method: 'POST',
+          path: '/my/path',
+          protocol: 'HTTP/1.1',
+          sourceIp: 'IP',
+          userAgent: 'agent'
+        },
+        requestId: 'id',
+        routeKey: '$default',
+        stage: '$default',
+        time: '12/Mar/2020:19:03:58 +0000',
+        timeEpoch: 1583348638390
+      },
+      body: 'Hello from Lambda',
+      pathParameters: { 'parameter1': 'value1' },
+      isBase64Encoded: false,
+      stageVariables: { 'stageVariable1': 'value1', 'stageVariable2': 'value2' }
+    };
+
+    // Clean the event
+    cleanUpEvent(v2Event, { basePath: '/my' });
+
+    expect(v2Event).to.eql({
+      version: '2.0',
+      routeKey: '$default',
+      rawPath: '/path',
+      rawQueryString: 'parameter%231=value%231&parameter%231=value%232&parameter2=value',
+      cookies: ['cookie1', 'cookie2'],
+      headers: { Header1: 'value1', Header2: 'value2' },
+      queryStringParameters: { 'parameter%231': 'value%231,value%232', 'parameter2': 'value' },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'api-id',
+        authorizer: {
+          jwt: {
+            claims: { 'claim1': 'value1', 'claim2': 'value2' },
+            scopes: ['scope1', 'scope2']
+          }
+        },
+        domainName: 'id.execute-api.us-east-1.amazonaws.com',
+        domainPrefix: 'id',
+        http: {
+          method: 'POST',
+          path: '/my/path',
+          protocol: 'HTTP/1.1',
+          sourceIp: 'IP',
+          userAgent: 'agent'
+        },
+        requestId: 'id',
+        routeKey: '$default',
+        stage: '$default',
+        time: '12/Mar/2020:19:03:58 +0000',
+        timeEpoch: 1583348638390
+      },
+      body: 'Hello from Lambda',
+      pathParameters: { parameter1: 'value1' },
+      isBase64Encoded: false,
+      stageVariables: { stageVariable1: 'value1', stageVariable2: 'value2' }
+    });
+
+  });
 });


### PR DESCRIPTION
When using AWS Elastic Load Balancer with Target Groups that point to Lambda functions, the event payload slightly differs from API Gateway in that API Gateway appears to automatically decode URL query parameters, whereas AWS ELB does not automatically decode URL query parameters.

We fix this by checking if `requestContext.elb` exists, and if so, we decode the URL query parameters to normalize it the same way that API Gateway does.