### PR TITLE
Add chunked encoding support

### DIFF
--- a/lib/provider/aws/format-response.js
+++ b/lib/provider/aws/format-response.js
@@ -28,7 +28,7 @@ module.exports = (event, response, options) => {
         parsed.push(value.substring(0, size));
       }
     }
-    body = parsed.join()
+    body = parsed.join('')
   }
 
   let formattedResponse = { statusCode, headers, isBase64Encoded, body };

--- a/lib/provider/aws/format-response.js
+++ b/lib/provider/aws/format-response.js
@@ -8,10 +8,6 @@ module.exports = (event, response, options) => {
   const { statusCode } = response;
   const {headers, multiValueHeaders } = sanitizeHeaders(Response.headers(response));
 
-  if (headers['transfer-encoding'] === 'chunked' || response.chunkedEncoding) {
-    throw new Error('chunked encoding not supported');
-  }
-
   let cookies = [];
 
   if (multiValueHeaders['set-cookie']) {
@@ -20,7 +16,20 @@ module.exports = (event, response, options) => {
 
   const isBase64Encoded = isBinary(headers, options);
   const encoding = isBase64Encoded ? 'base64' : 'utf8';
-  const body = Response.body(response).toString(encoding);
+  let body = Response.body(response).toString(encoding);
+
+  if (headers['transfer-encoding'] === 'chunked' || response.chunkedEncoding) {
+    const raw = Response.body(response).toString().split('\r\n');
+    const parsed = [];
+    for (let i = 0; i < raw.length; i +=2) {
+      const size = parseInt(raw[i], 16);
+      const value = raw[i + 1];
+      if (value) {
+        parsed.push(value.substring(0, size));
+      }
+    }
+    body = parsed.join()
+  }
 
   let formattedResponse = { statusCode, headers, isBase64Encoded, body };
 

--- a/test/format-response.js
+++ b/test/format-response.js
@@ -39,9 +39,9 @@ describe('format-response', function () {
       stageVariables: null,
       body: 'Hello from Lambda!',
       isBase64Encoded: true
-};
+  };
     
-// Construct dummy v2 event
+    // Construct dummy v2 event
     const v2Event = {
       version: '2.0',
       routeKey: '$default',
@@ -83,36 +83,47 @@ describe('format-response', function () {
       stageVariables: { 'stageVariable1': 'value1', 'stageVariable2': 'value2' }
     };
 
-  it('throws on chunked transfer-encoding on v1Event', () => {
-    const response = new Response({});
-    response.setHeader('transfer-encoding', 'chunked');
-    expect(() => formatResponse(v1Event, response, {})).to.throw(Error, 'chunked encoding not supported');
+  it('parses chunked body on chunked transfer-encoding on v1Event', () => {
+    const chunkedBody = '7\r\nCombine\r\n4\r\nThis\r\n4\r\nText\r\n0\r\n\r\n';
+    const response = Response.from({
+      body: chunkedBody,
+      headers: { 'transfer-encoding': 'chunked'},
+      statusCode: 200
+    })
+    expect(formatResponse(v1Event, response, {}).body).to.eql('CombineThisText');
   });
 
-  it('throws on res.chunkedEncoding on v1Event', () => {
-    const response = new Response({});
+  it('parses chunked body on res.chunkedEncoding on v1Event', () => {
+    const chunkedBody = '7\r\nCombine\r\n4\r\nThis\r\n4\r\nText\r\n0\r\n\r\n';
+    const response = Response.from({
+      body: chunkedBody,
+      statusCode: 200
+    })
     response.chunkedEncoding = true;
 
-    expect(() => formatResponse(v1Event, response, {})).to.throw(Error, 'chunked encoding not supported');
+    expect(formatResponse(v1Event, response, {}).body).to.eql('CombineThisText');
+
   });
 
-  it("throws on chunked transfer-encoding on v2Event", () => {
-    const response = new Response({});
-    response.setHeader("transfer-encoding", "chunked");
-    expect(() => formatResponse(v2Event, response, {})).to.throw(
-      Error,
-      "chunked encoding not supported"
-    );
+  it("parses chunked body on transfer-encoding on v2Event", () => {
+    const chunkedBody = '7\r\nCombine\r\n4\r\nThis\r\n4\r\nText\r\n0\r\n\r\n';
+    const response = Response.from({
+      body: chunkedBody,
+      headers: { 'transfer-encoding': 'chunked'},
+      statusCode: 200
+    })
+    expect(formatResponse(v2Event, response, {}).body).to.eql('CombineThisText');
+
   });
 
-  it("throws on res.chunkedEncoding on v2Event", () => {
-    const response = new Response({});
+  it("parses chunked body on res.chunkedEncoding on v2Event", () => {
+    const chunkedBody = '7\r\nCombine\r\n4\r\nThis\r\n4\r\nText\r\n0\r\n\r\n';
+    const response = Response.from({
+      body: chunkedBody,
+      statusCode: 200
+    })
     response.chunkedEncoding = true;
-
-    expect(() => formatResponse(v2Event, response, {})).to.throw(
-      Error,
-      "chunked encoding not supported"
-    );
+    expect(formatResponse(v1Event, response, {}).body).to.eql('CombineThisText');
   });
 
   it("v2Event: return object contains cookies", () => {


### PR DESCRIPTION
Didn't dig too deep on how the response.body gets hydrated -- assuming that the whole body is there, just hasn't been parsed correctly.

Read a little about the transfer-chunk encoding and wrote some logic to parse it.


Read 
https://github.com/dougmoscrop/serverless-http/issues/142

and decided to see if the lib itself could handler this portion of the logic. 

Let me know what you think.
