### PR TITLE
adding support for multi value headers

### DIFF
--- a/lib/provider/aws/create-request.js
+++ b/lib/provider/aws/create-request.js
@@ -23,6 +23,13 @@ function requestHeaders(event) {
     ? { cookie: event.cookies.join('; ') }
     : {};
 
+  if (event.multiValueHeaders) {
+    return Object.keys(event.multiValueHeaders).reduce((headers, key) => {
+      headers[key.toLowerCase()] = event.multiValueHeaders[key].join(", ")
+      return headers;
+    }, initialHeader);
+  }
+
   return Object.keys(event.headers).reduce((headers, key) => {
     headers[key.toLowerCase()] = event.headers[key];
     return headers;


### PR DESCRIPTION
Currently using lambda with ALB load balancer with multi value headers support. We are receiving all headers in the key "multiValueHeaders". This will comma separate multi value headers provided by the load balancer.