### PR TITLE
Support UInt8Array data in response

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -18,7 +18,7 @@ function getString(data) {
 }
 
 function addData(stream, data) {
-  if (Buffer.isBuffer(data) || typeof data === 'string') {
+  if (Buffer.isBuffer(data) || typeof data === 'string' || data instanceof Uint8Array) {
     stream[BODY].push(Buffer.from(data));
   } else {
     throw new Error(`response.write() of unexpected type: ${typeof data}`);

--- a/test/spec.js
+++ b/test/spec.js
@@ -427,4 +427,22 @@ describe('spec', () => {
     expect(response.headers).to.have.property('location', '/foo');
   });
 
+  it('should support UInt8Array data', async () => {
+    const expected = "hello";
+
+    const uint8Array = Uint8Array.from(
+      Array.from(expected).map(
+        ch => ch.charCodeAt(0)
+      )
+    );
+
+    const handler = serverless((req, res) => {
+      res.end(uint8Array);
+    });
+
+    const response = await handler({});
+
+    expect(response.body).to.equal(expected);
+  });
+
 });


### PR DESCRIPTION
Next.js 12.1 SSR delivers response data in UInt8Array format. In Node.js both string and UInt8Array are supported in function signature. See https://nodejs.org/dist/latest-v16.x/docs/api/buffer.html#static-method-bufferfrombuffer

With this fix, SSR (via getServerSideProps) is made possible in Next.js standalone mode. 