### PR TITLE
bug: azure: switch to rawbody to match content length

### DIFF
--- a/lib/provider/azure/create-request.js
+++ b/lib/provider/azure/create-request.js
@@ -12,17 +12,17 @@ function requestHeaders(request) {
 }
 
 function requestBody(request) {
-    const type = typeof request.body;
+    const type = typeof request.rawBody;
 
-    if (Buffer.isBuffer(request.body)) {
-        return request.body;
+    if (Buffer.isBuffer(request.rawBody)) {
+        return request.rawBody;
     } else if (type === 'string') {
-        return Buffer.from(request.body, 'utf8');
+        return Buffer.from(request.rawBody, 'utf8');
     } else if (type === 'object') {
-        return Buffer.from(JSON.stringify(request.body));
+        return Buffer.from(JSON.stringify(request.rawBody));
     }
 
-    throw new Error(`Unexpected request.body type: ${typeof request.body}`);
+    throw new Error(`Unexpected request.body type: ${typeof request.rawBody}`);
 }
 
 module.exports = (request) => {


### PR DESCRIPTION
When posting a request with a json body, Azure lightly parses the content body causing the content-length to mismatch and reject. Switch to rawBody to prevent.