### PR TITLE
#245 Add basePath to type definition for Options

### DIFF
--- a/serverless-http.d.ts
+++ b/serverless-http.d.ts
@@ -21,7 +21,8 @@ declare namespace ServerlessHttp {
     requestId?: string,
     request?: Object | Function,
     response?: Object | Function,
-    binary?: boolean | Function | string | string[]
+    binary?: boolean | Function | string | string[],
+    basePath?: string
   }
   /**
    * AWS Lambda APIGatewayProxyHandler-like handler.


### PR DESCRIPTION
Fix #245 by adding in an optional basePath field to the Options type definition.