### PR TITLE
feat: add example for AWS/Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,27 @@ module.exports.funcName = async (context, req) => {
 
 ```
 
+### Usage example using the Express framework with AWS
+
+```javascript
+
+const serverless = require('serverless-http');
+const express = require('express');
+
+const app = express();
+
+app.use(/* register your middleware as normal */);
+
+const handler = serverless(app, { provider: 'aws' });
+module.exports.handler = async (event, context, callback) => {
+    console.log(event);
+    const res = await handler(event, context);
+    
+    callback(null, res);
+}
+
+```
+
 ### Other examples
 [json-server-less-λ](https://github.com/pharindoko/json-server-less-lambda) - using serverless-http with json-server and serverless framework in AWS
 


### PR DESCRIPTION
I've been playing with your framework (great work, btw) and felt like a tutorial for AWS/Express usage would be a great addition for newcomers.

This code snipped was tested in AWS!