### PR TITLE
feat: Emit close event on http.ServerResponse

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -126,6 +126,10 @@ module.exports = class ServerlessResponse extends http.ServerResponse {
         }
       },
     });
+
+    this.once('finish', () => {
+      this.emit('close')
+    });
   }
 
 };

--- a/test/generic.js
+++ b/test/generic.js
@@ -3,7 +3,8 @@
 const url = require('url'),
   fs = require('fs'),
   expect = require('chai').expect,
-  request = require('./util/request');
+  request = require('./util/request'),
+  sinon = require('sinon');
 
 describe('generic http listener', () => {
   let app;
@@ -151,6 +152,23 @@ describe('generic http listener', () => {
         location: '/redirect',
         accept: '*/*'
       });
+    });
+  });
+
+  it('should emit close once', () => {
+    const stub = sinon.stub().returns(true);
+    app = function (req, res) {
+      res.on('close', stub);
+      res.writeHead(200);
+      res.emit('finish'); // Test multiple finish deliveries
+      res.end();
+    };
+
+    return request(app, {
+      httpMethod: 'GET',
+      path: '/',
+    }).then(() => {
+      expect(stub.calledOnce).to.be.true;
     });
   });
 });


### PR DESCRIPTION
I want to preface this with the fact that I don't know much about the Node internals patched by this library here, so please do help me correct any misunderstandings as I'm sure there are several.

I ran into an issue in [dd-trace](https://github.com/datadog/dd-trace-js) where an instance of `http.ServerResponse` emitted only `finish` and not `close`. Based on my understanding of the [docs](https://nodejs.org/api/http.html#event-close_2), we'd expect to see `finish` and `close` after an instance of `http.ServerResponse` has finished and the response written to the network interface.

To verify that understanding, I wrote a tiny webserver and confirmed the behavior:
```js
'use strict'
const http = require('http')

const myListener = (req, res) => {
  res.on('close', () => { console.log('response received close') })
  res.on('finish', () => { console.log('response received finish') })
  res.writeHead(200)
  res.end(JSON.stringify({receivedRequest: true}))
}

const server = http.createServer(myListener)
server.listen(1337, '127.0.0.1', () => { console.log('running') })
```
<img width="568" alt="image" src="https://user-images.githubusercontent.com/1598537/209399283-d9394c80-9da8-44a3-a282-0933bfdf2d34.png">

However, while tracking down this [issue](https://github.com/DataDog/serverless-plugin-datadog/issues/324), I noticed that running this library (with express, specifically) within a lambda function doesn't emit `close` when the response is finished. Rather only `finish` is emitted from the `http.ServerResponse`. This caused Datadog to buffer traces (as our APM telemetry didn't think the response was done), and never flush.

I fixed this on our side [here](https://github.com/DataDog/dd-trace-js/pull/2625), but I wanted to fix this upstream.

If I understand correctly, Node should [automatically](https://github.com/nodejs/node/blob/f8bc4ced73fce25a489911d405dca80ee52eb216/lib/_http_server.js#L278) emit close when the socket receives close, but that doesn't happen here as our socket doesn't ever really `close`.

Here's a similar [implementation](https://github.com/debitoor/multifetch/blob/0dc4aea2c98eb9d3b6916f7056834d4165407e61/source/http.js#L161-L163) which manually plumbs a socket to a response, where they call `socket.end()` when `response#finish` is received; so this is the route I chose here.