### PR TITLE
Issue #278 return boolean value is assignSocket, buf connect support grpc

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -124,6 +124,7 @@ module.exports = class ServerlessResponse extends http.ServerResponse {
         if (typeof cb === 'function') {
           cb();
         }
+        return true;
       },
     });
 


### PR DESCRIPTION
This is a simple solution for being able to run `serverless-http`, `express`, and `@bufbuild/connect` in a serverless runtime. See https://github.com/dougmoscrop/serverless-http/issues/278.