### PR TITLE
fix: use correct key for headers on alb responses when multiValueHeaders is set

### DIFF
--- a/lib/provider/aws/format-response.js
+++ b/lib/provider/aws/format-response.js
@@ -3,10 +3,23 @@
 const isBinary = require('./is-binary');
 const Response = require('../../response');
 const sanitizeHeaders = require('./sanitize-headers');
+const { getEventType, LAMBDA_EVENT_TYPES } = require('./get-event-type');
+
+const combineHeaders = (headers, multiValueHeaders) => {
+  return Object.entries(headers).reduce((memo, [key, value]) => {
+    if (multiValueHeaders[key]) {
+      memo[key].push(value);
+    } else {
+      memo[key] = [value];
+    }
+    return memo;
+  }, multiValueHeaders);
+}
 
 module.exports = (event, response, options) => {
+  const eventType = getEventType(event);
   const { statusCode } = response;
-  const {headers, multiValueHeaders } = sanitizeHeaders(Response.headers(response));
+  const { headers, multiValueHeaders } = sanitizeHeaders(Response.headers(response));
 
   let cookies = [];
 
@@ -31,15 +44,20 @@ module.exports = (event, response, options) => {
     body = parsed.join('')
   }
 
-  let formattedResponse = { statusCode, headers, isBase64Encoded, body };
-
-  if (event.version === '2.0' && cookies.length) {
-    formattedResponse['cookies'] = cookies;
+  if (eventType === LAMBDA_EVENT_TYPES.ALB) {
+    const albResponse = { statusCode, isBase64Encoded, body };
+    if (event.multiValueHeaders) {
+      albResponse.multiValueHeaders = combineHeaders(headers, multiValueHeaders);
+    } else {
+      albResponse.headers = headers;
+    }
+    return albResponse;
   }
 
-  if ((!event.version || event.version === '1.0') && Object.keys(multiValueHeaders).length) {
-    formattedResponse['multiValueHeaders'] = multiValueHeaders;
+  if (eventType === LAMBDA_EVENT_TYPES.HTTP_API_V2) {
+    return { statusCode, isBase64Encoded, body, headers, cookies };
   }
 
-  return formattedResponse;
+  // HTTP_API_V1 is the default
+  return { statusCode, isBase64Encoded, body, headers, multiValueHeaders };
 };

--- a/lib/provider/aws/get-event-type.js
+++ b/lib/provider/aws/get-event-type.js
@@ -1,0 +1,27 @@
+const HTTP_API_V1 = 'HTTP_API_V1';
+const HTTP_API_V2 = 'HTTP_API_V2';
+const ALB = 'ALB';
+
+const LAMBDA_EVENT_TYPES = {
+    HTTP_API_V1,
+    HTTP_API_V2,
+    ALB
+}
+
+const getEventType = (event) => {
+    if (event.requestContext && event.requestContext.elb) {
+    // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html
+        return ALB;
+    } else if (event.version === '2.0') {
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
+        return HTTP_API_V2;
+    } else {
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
+        return HTTP_API_V1;
+    }
+}
+
+module.exports = {
+    getEventType,
+    LAMBDA_EVENT_TYPES
+}

--- a/test/get-event-type.js
+++ b/test/get-event-type.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { getEventType, LAMBDA_EVENT_TYPES } = require('../lib/provider/aws/get-event-type');
+const expect = require('chai').expect;
+
+describe('getEventType', function () {
+
+    it('handles an ALB event', () => {
+        const event = { requestContext: { elb: { arn: 'foo' } } };
+        expect(getEventType(event)).to.equal(LAMBDA_EVENT_TYPES.ALB);
+    });
+
+    it('handles an HTTP_API_V2 event', () => {
+        const event = { version: '2.0' };
+        expect(getEventType(event)).to.equal(LAMBDA_EVENT_TYPES.HTTP_API_V2);
+    });
+    
+    it('handles an HTTP_API_V1 event', () => {
+        const event = { version: '1.0' };
+        expect(getEventType(event)).to.equal(LAMBDA_EVENT_TYPES.HTTP_API_V1);
+    });
+
+  
+
+});


### PR DESCRIPTION
There is a bug/missing functionality in the library currently when trying to set headers on the response when using an ALB Lambda trigger with multiValueHeaders.

In the case of an [ALB event](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html) 

> ### Responses with multi-value headers
> The names of the fields used for headers differ depending on whether you enable multi-value headers for the target group. You must use multiValueHeaders if you have enabled multi-value headers and headers otherwise.

The current implementation will return single value headers in the `headers` key which means if multiValueHeaders are enabled those headers go missing.

This PR aims to resolve the above issue and clean up the format function so that it can handle response formats for HTTP apis (V1 and V2) as well as ALB style responses.
