### PR TITLE
Support running on the Bun Runtime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,31 @@ module.exports.funcName = async (context, req) => {
 
 ```
 
+### Usage example using the Koa framework with AWS [Bun](https://github.com/oven-sh/bun/blob/main/packages/bun-lambda) Runtime
+
+```javascript
+const serverless = require('serverless-http');
+const Koa = require('koa'); // or any supported framework
+
+const app = new Koa();
+
+app.use(/* register your middleware as normal */);
+
+// this is it!
+module.exports.handler = serverless(app);
+
+// or as a promise
+const handler = serverless(app, { provider: 'bunAws' });
+module.exports.handler = async (event, context) => {
+  // you can do other things here
+  const result = await handler(event, context);
+  // and here
+  return result;
+};
+```
+
+How to setup Bun AWS Lambda, see https://learnaws.io/blog/bun-aws-lambda
+
 ### Other examples
 [json-server-less-λ](https://github.com/pharindoko/json-server-less-lambda) - using serverless-http with json-server and serverless framework in AWS
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ module.exports.funcName = async (context, req) => {
 
 ```
 
-### Usage example using the Koa framework with AWS [Bun](https://github.com/oven-sh/bun/blob/main/packages/bun-lambda) Runtime
+### Usage example using the Koa framework with [AWS Bun Runtime](https://github.com/oven-sh/bun/blob/main/packages/bun-lambda)
 
 ```javascript
 const serverless = require('serverless-http');
@@ -105,10 +105,6 @@ const app = new Koa();
 
 app.use(/* register your middleware as normal */);
 
-// this is it!
-module.exports.handler = serverless(app);
-
-// or as a promise
 const handler = serverless(app, { provider: 'bunAws' });
 module.exports.handler = async (event, context) => {
   // you can do other things here

--- a/lib/provider/bun-aws/index.js
+++ b/lib/provider/bun-aws/index.js
@@ -1,0 +1,17 @@
+// https://learnaws.io/blog/bun-aws-lambda
+
+const cleanUpEvent = require('../aws/clean-up-event');
+
+const createRequest = require('../aws/create-request');
+const formatResponse = require('../aws/format-response');
+
+module.exports = options => {
+  return getResponse => async (event_, context = {}) => {
+    const event = cleanUpEvent(event_.aws, options);
+
+    const request = createRequest(event, context, options);
+    const response = await getResponse(request, event, context);
+
+    return formatResponse(event, response, options);
+  };
+};

--- a/lib/provider/get-provider.js
+++ b/lib/provider/get-provider.js
@@ -1,9 +1,11 @@
 const aws = require('./aws');
 const azure = require('./azure');
+const bunAws = require('./bun-aws');
 
 const providers = {
   aws,
-  azure
+  azure,
+  bunAws,
 };
 
 module.exports = function getProvider(options) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,10 @@ const http = require('http');
 module.exports = class ServerlessRequest extends http.IncomingMessage {
   constructor({ method, url, headers, body, remoteAddress }) {
     super({
+      // Bun uses url to create a new URL: https://github.com/oven-sh/bun/blob/main/src/js/node/http.ts#L580
+      url,
+      // Bun uses method to set noBody props: https://github.com/oven-sh/bun/blob/main/src/js/node/http.ts#L584
+      method,
       encrypted: true,
       readable: false,
       remoteAddress,

--- a/serverless-http.d.ts
+++ b/serverless-http.d.ts
@@ -17,7 +17,7 @@ declare namespace ServerlessHttp {
   export type Result = Function | Partial<FrameworkApplication>;
 
   export type Options = {
-    provider?: 'aws' | 'azure'
+    provider?: 'aws' | 'azure' | 'bunAws',
     requestId?: string,
     request?: Object | Function,
     response?: Object | Function,


### PR DESCRIPTION
Make serverless-http compatible with the official [Bun Lambda Runtime](https://github.com/oven-sh/bun/blob/main/packages/bun-lambda/runtime.ts).

Use Bun Lambda Runtime in AWS, see https://learnaws.io/blog/bun-aws-lambda